### PR TITLE
Updated CAPABILITY_MEASURE_POWER for return power

### DIFF
--- a/drivers/domoticz_device/device.js
+++ b/drivers/domoticz_device/device.js
@@ -57,7 +57,8 @@ class DomoticzDevice extends Homey.Device{
                     }
                     break;
                 case CAPABILITY_MEASURE_POWER:
-                    value = parseFloat(data.Usage.split(" ")[0]);
+                    const powerDelivery = data.UsageDeliv ? parseFloat(data.UsageDeliv.split(" ")[0]) : 0;
+                    value = parseFloat(data.Usage.split(" ")[0]) - powerDelivery;
                     break;
                 case CAPABILITY_METER_POWER:
                     value = parseFloat(data.CounterToday.split(" ")[0]);


### PR DESCRIPTION
This updates the current usage to include a possible return power, via API returned as usageDeliv.
Simply subtracting this number from usage, so we see a negative value (similar to Domoticz)